### PR TITLE
hotfix: 스케줄러 비활성화해도 한번 실행되는 현상 해결

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,6 @@ from contextlib import asynccontextmanager
 
 from core.logging import setup_logging
 from fastapi import FastAPI
-from tasks.auth_scheduler import auth_scheduler
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -13,13 +12,21 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     disable_scheduler = os.getenv("DISABLE_SCHEDULER", "false").lower() == "true"
+    scheduler = None
 
     if disable_scheduler:
         logger.info("auth 비활성화")
     else:
-        auth_scheduler.start()
+        from tasks.auth_scheduler import AuthScheduler
+
+        scheduler = AuthScheduler()
+        scheduler.start()
 
     yield
+
+    if scheduler:
+        scheduler.stop()
+        logger.info("Auth scheduler stopped during shutdown")
 
 
 app = FastAPI(title="Trading Server", lifespan=lifespan)

--- a/app/tasks/auth_scheduler.py
+++ b/app/tasks/auth_scheduler.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from core.kis_auth import auth
@@ -8,12 +9,25 @@ logger = logging.getLogger(__name__)
 
 
 class AuthScheduler:
-    """KIS 인증을 백그라운드에서 주기적으로 갱신하는 스케줄러."""
+    """KIS 인증을 백그라운드에서 주기적으로 갱신하는 스케줄러. Thread-safe Singleton."""
+
+    _instance = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
 
     def __init__(self) -> None:
+        if hasattr(self, "_initialized"):
+            return
         self.scheduler = AsyncIOScheduler(timezone="Asia/Seoul")
         self._is_running = False
         self._bg_task: asyncio.Task[None] | None = None
+        self._initialized = True
 
     def start(self) -> None:
         """매일 밤 10시에 인증을 수행하고, 부팅 시 즉시 1회 인증을 시도한다."""
@@ -58,6 +72,3 @@ class AuthScheduler:
             raise
         except Exception as e:
             logger.error("Background auth refresh failed: %s", e)
-
-
-auth_scheduler = AuthScheduler()


### PR DESCRIPTION
기존 `./server.sh dev` 명령어로 스케줄러를 비활성화 해도, 상단 `import` 문에서 AuthScheduer 가 한번 실행되는 현상이 있어 해당 문제를 해결하였습니다.

* **기존**: Module-level Singleton
* **새방식**: Thread-Safe Singleton + Lazy Import