### PR TITLE
첫시작시 토큰 강제 초기화

### DIFF
--- a/app/core/kis_auth.py
+++ b/app/core/kis_auth.py
@@ -82,7 +82,9 @@ def get_base_header():
 
 
 def auth(
-    svr: str | RunMode = RunMode.PROD, product: ProductCode = _kis_cfg.my_prod, url=None
+    svr: str | RunMode = RunMode.PROD,
+    product: ProductCode = _kis_cfg.my_prod,
+    force: bool = False
 ):
     """
     - access_token 발급
@@ -102,7 +104,7 @@ def auth(
 
     saved_token: str | None = read_token()
 
-    if saved_token is None:
+    if saved_token is None or force:
         p = {
             "grant_type": "client_credentials",
             "appkey": appkey,

--- a/app/tasks/auth_scheduler.py
+++ b/app/tasks/auth_scheduler.py
@@ -48,7 +48,7 @@ class AuthScheduler:
         self.scheduler.start()
 
         # 서버 부팅 직후 인증 상태를 보장하기 위해 즉시 1회 수행
-        self._bg_task = asyncio.create_task(self.refresh_auth_job())
+        self._bg_task = asyncio.create_task(self.refresh_auth_job(force=True))
         self._is_running = True
         logger.info("Auth scheduler started")
 
@@ -63,11 +63,11 @@ class AuthScheduler:
         self._is_running = False
         logger.info("Auth scheduler stopped")
 
-    async def refresh_auth_job(self) -> None:
+    async def refresh_auth_job(self, force: bool = False) -> None:
         """실제 인증 작업을 수행하는 스케줄러 Job."""
         try:
-            await asyncio.to_thread(auth)
-            logger.info("Background auth refresh completed")
+            await asyncio.to_thread(auth, force=force)
+            logger.info("Background auth refresh completed (force=%s)", force)
         except asyncio.CancelledError:
             raise
         except Exception as e:


### PR DESCRIPTION
기존에 프로젝트가 배포되면 기존 토큰값을 재사용하는 로직 때문에 토큰이 제대로 초기화 되지 않는 오류 수정